### PR TITLE
Forked off for python-wrapper compatibility.

### DIFF
--- a/examples/3ds_emu_powerslaves_wrapper.py
+++ b/examples/3ds_emu_powerslaves_wrapper.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python
+import os
+
+#execute stuff from bash
+#	>pipe output to stdout
+#handle stdin/stdout from python
+#	>get output of arbitrary from stdin
+#handle blowfish 
+#make a simple shell for testing
+
+def powerslaves_arbitrary_read(cmd, cmd_len):
+	"cmd is a hexidecimal string starting with 0x, len is an \
+	 integer < 4096 (multiples of 4 plz)"
+	base_command = "sudo ./arbitrary "
+	constr_command = base_command + cmd[2:18] + " " + str(cmd_len)
+	stdout_data = os.popen(constr_command).read()
+	return stdout_data
+
+def main_loop():
+
+	cmd = "0x0000000000000000"
+	cmd_len	= 1000
+	arb_ret = powerslaves_arbitrary_read(cmd, cmd_len)
+	print arb_ret
+	return 
+
+
+if __name__ == "__main__":
+	main_loop()
+

--- a/examples/arbitrary.c
+++ b/examples/arbitrary.c
@@ -6,7 +6,7 @@
 #include <stdbool.h>
 #include <string.h>
 
-static const uint8_t dummy_cmd[] = {0x9F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+//static const uint8_t dummy_cmd[] = {0x9F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
 int main(int argc, char *argv[]) {
     if (powerslaves_select(NULL)) {
@@ -37,14 +37,19 @@ int main(int argc, char *argv[]) {
     memset(returnbuf, 0, length);
     powerslaves_sendreceive(NTR, cmd, length, returnbuf);
 
+    /*
     FILE *datafile = fopen("arbitrary.bin", "wb");
     fwrite(returnbuf, length, 1, datafile);
     free(returnbuf);
+    */
 
-    // for (size_t iii = 0; iii < length; ++iii) {
-    //     printf("%02x", returnbuf[iii]);
-    // }
-    // puts("");
+
+    
+    for (size_t iii = 0; iii < length; ++iii) {
+        putchar((char)returnbuf[iii]);
+    }
+    puts("");
+    
 
     return 0;
 }


### PR DESCRIPTION
Created a python wrapper for automating/emulating comms, and modified examples/arbitrary.c to send raw binary data to stdout for loading in python. If pull request is accepted, recommend maintaining as separate branch.